### PR TITLE
Integrate server‑side GPT‑4o agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,8 +78,14 @@ Seeker now supports OpenAI's GPT-4o model for enhanced browser automation perfor
    ```
    OPENAI_MODEL=gpt-4o
    OPENAI_TEMPERATURE=0.0
-   OPENAI_USE_VISION=true
-   ```
+  OPENAI_USE_VISION=true
+  ```
+
+4. Tasks that use GPT-4o are executed through the `/api/agent` route. This
+   server endpoint runs the OpenAI powered browser agent and returns detailed
+   steps along with a final answer. You can optionally pass your API keys in the
+   request body, otherwise the server will use keys defined in environment
+   variables.
 
 ### Benefits of OpenAI Integration
 

--- a/app/api/agent/route.ts
+++ b/app/api/agent/route.ts
@@ -4,14 +4,23 @@ import { runOpenAIBrowserTask, OpenAIBrowserAgentConfig } from '../../../agent/b
 export async function POST(request: Request) {
   try {
     const body = await request.json();
-    const { question, taskDescription, model, temperature, useVision, browserUseBaseUrl } = body;
+    const {
+      question,
+      taskDescription,
+      model,
+      temperature,
+      useVision,
+      browserUseBaseUrl,
+      openAIApiKey: bodyOpenAIKey,
+      browserUseApiKey: bodyBrowserUseKey,
+    } = body;
 
     if (!question) {
       return NextResponse.json({ error: 'Question is required' }, { status: 400 });
     }
 
-    const openAIApiKey = process.env.OPENAI_API_KEY;
-    const browserUseApiKey = process.env.BROWSER_USE_API_KEY;
+    const openAIApiKey = bodyOpenAIKey || process.env.OPENAI_API_KEY;
+    const browserUseApiKey = bodyBrowserUseKey || process.env.BROWSER_USE_API_KEY;
 
     if (!openAIApiKey) {
       console.error('OpenAI API key is not configured on the server.');

--- a/hooks/use-browser-task-manager.ts
+++ b/hooks/use-browser-task-manager.ts
@@ -120,12 +120,7 @@ export function useBrowserTaskManager({
     }
 
     if (usingOpenAI) {
-      // Check for OpenAI API key
-      if (!openAIKey) {
-        throw new Error('OpenAI API key is required when using GPT-4o integration');
-      }
-
-      // Use OpenAI-powered agent
+      // Use OpenAI-powered agent (executed on the server)
       await openAIRunTask(taskDescription);
       setUsingOpenAI(true);
     } else {


### PR DESCRIPTION
## Summary
- run the GPT‑4o browser agent on the `/api/agent` backend endpoint
- allow API route to accept API keys from the request body
- update the OpenAI task hook to call the backend instead of running locally
- simplify task manager execution logic
- document the new server agent endpoint in the README

## Testing
- `npm run lint` *(fails: `next` not found)*